### PR TITLE
Extended-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comply",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comply",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comply",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Comply is a tiny library to help you define policies in your app",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -620,3 +620,210 @@ describe("Inference", () => {
     }
   });
 });
+
+describe("Logical operators", () => {
+  type Context = { userId: string };
+  type Post = { userId: string; comments: string[]; status: "published" | "draft" | "archived" };
+
+  it("should [or] accept predicates", () => {
+    const PostPolicies = definePolicies((context: Context) => {
+      const myPostPolicy = definePolicy(
+        "my post",
+        (post: Post) => post.userId === context.userId,
+        () => new Error("Not the author")
+      );
+
+      return [
+        myPostPolicy,
+        definePolicy("all published posts or mine", (post: Post) =>
+          or(
+            () => check(myPostPolicy, post),
+            () => post.status === "published"
+          )
+        ),
+      ];
+    });
+
+    const guard = {
+      post: PostPolicies({ userId: "1" }),
+    };
+
+    expect(
+      check(guard.post.policy("all published posts or mine"), { userId: "1", comments: [], status: "draft" })
+    ).toBe(true);
+    expect(
+      check(guard.post.policy("all published posts or mine"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toBe(true);
+    expect(
+      check(guard.post.policy("all published posts or mine"), { userId: "2", comments: [], status: "draft" })
+    ).toBe(false);
+
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), { userId: "1", comments: [], status: "draft" })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), { userId: "2", comments: [], status: "draft" })
+    ).toThrowError();
+  });
+
+  it("should [or] accept booleans", () => {
+    const PostPolicies = definePolicies((context: Context) => {
+      const myPostPolicy = definePolicy(
+        "my post",
+        (post: Post) => post.userId === context.userId,
+        () => new Error("Not the author")
+      );
+
+      return [
+        myPostPolicy,
+        definePolicy("all published posts or mine", (post: Post) =>
+          or(check(myPostPolicy, post), post.status === "published")
+        ),
+      ];
+    });
+
+    const guard = {
+      post: PostPolicies({ userId: "1" }),
+    };
+
+    expect(
+      check(guard.post.policy("all published posts or mine"), { userId: "1", comments: [], status: "draft" })
+    ).toBe(true);
+    expect(
+      check(guard.post.policy("all published posts or mine"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toBe(true);
+    expect(
+      check(guard.post.policy("all published posts or mine"), { userId: "2", comments: [], status: "draft" })
+    ).toBe(false);
+
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), { userId: "1", comments: [], status: "draft" })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all published posts or mine"), { userId: "2", comments: [], status: "draft" })
+    ).toThrowError();
+  });
+
+  it("should [and] accept predicates", () => {
+    const PostPolicies = definePolicies((context: Context) => {
+      const myPostPolicy = definePolicy(
+        "my post",
+        (post: Post) => post.userId === context.userId,
+        () => new Error("Not the author")
+      );
+
+      return [
+        myPostPolicy,
+        definePolicy("all my published posts", (post: Post) =>
+          and(
+            () => check(myPostPolicy, post),
+            () => post.status === "published"
+          )
+        ),
+      ];
+    });
+
+    const guard = {
+      post: PostPolicies({ userId: "1" }),
+    };
+
+    expect(check(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "published" })).toBe(
+      true
+    );
+    expect(check(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "draft" })).toBe(
+      false
+    );
+    expect(
+      check(guard.post.policy("all my published posts"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toBe(false);
+
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "published" })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "draft" })
+    ).toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toThrowError();
+  });
+
+  it("should [and] accept booleans", () => {
+    const PostPolicies = definePolicies((context: Context) => {
+      const myPostPolicy = definePolicy(
+        "my post",
+        (post: Post) => post.userId === context.userId,
+        () => new Error("Not the author")
+      );
+
+      return [
+        myPostPolicy,
+        definePolicy("all my published posts", (post: Post) =>
+          and(check(myPostPolicy, post), post.status === "published")
+        ),
+      ];
+    });
+
+    const guard = {
+      post: PostPolicies({ userId: "1" }),
+    };
+
+    expect(check(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "published" })).toBe(
+      true
+    );
+    expect(check(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "draft" })).toBe(
+      false
+    );
+    expect(
+      check(guard.post.policy("all my published posts"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toBe(false);
+
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "published" })
+    ).not.toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), { userId: "1", comments: [], status: "draft" })
+    ).toThrowError();
+    expect(() =>
+      assert(guard.post.policy("all my published posts"), {
+        userId: "2",
+        comments: [],
+        status: "published",
+      })
+    ).toThrowError();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,9 +279,12 @@ export function definePolicies<Context, T extends PoliciesOrFactory>(defineOrPol
  *```
  */
 export function or(
-  ...conditions: (() => Policy<PolicyName, PolicyCondition, PolicyConditionArg<PolicyCondition>> | boolean)[]
+  ...conditions: (
+    | (() => Policy<PolicyName, PolicyCondition, PolicyConditionArg<PolicyCondition>> | boolean)
+    | boolean
+  )[]
 ) {
-  return conditions.some((predicate) => predicate());
+  return conditions.some((predicate) => (typeof predicate === "function" ? predicate() : predicate));
 }
 
 /**
@@ -322,9 +325,12 @@ export function or(
  *```
  */
 export function and(
-  ...conditions: (() => Policy<PolicyName, PolicyCondition, PolicyConditionArg<PolicyCondition>> | boolean)[]
+  ...conditions: (
+    | (() => Policy<PolicyName, PolicyCondition, PolicyConditionArg<PolicyCondition>> | boolean)
+    | boolean
+  )[]
 ) {
-  return conditions.every((predicate) => predicate());
+  return conditions.every((predicate) => (typeof predicate === "function" ? predicate() : predicate));
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
# Description

Allow the condition to be a function (lazy evaluation) or a boolean value.

The goal is to simplify the API for simple cases.
