### PR TITLE
👌 IMPROVE: checkAllSettle extended api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comply",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comply",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comply",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Comply is a tiny library to help you define policies in your app",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,9 +623,9 @@ type PoliciesSnapshot<TPolicyName extends string> = { [K in TPolicyName]: boolea
  * ```ts
  * // TLDR
   const snapshot = checkAllSettle([
-    [guard.post.policy("is my post"), post],
-    ["post has comments", post.comments.length > 0],
-    definePolicy("post has likes", post.likes.length > 0),
+    [guard.post.policy("is my post"), post], // Policy with argument
+    ["post has comments", post.comments.length > 0], // Implicit policy with no argument
+    definePolicy("post has likes", post.likes.length > 0), // Policy without argument. Can be used as is
   ]);
 
 // Example


### PR DESCRIPTION
# Description

The `checkAllSettle` tuple parameter can now take a policy with no argument directly instead of passing it into an array.

It should simplify the API.

```ts
  const snapshot = checkAllSettle([
    [guard.post.policy("is my post"), post], // Policy with argument
    ["post has comments", post.comments.length > 0], // Implicit policy with no argument
    definePolicy("post has likes", post.likes.length > 0), // Policy without argument. Can be used as is
  ]);
```